### PR TITLE
Netlify route rewrite

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
Configure Netlify rewrite rule for SPA to prevent 404 not found error on page refresh.

https://docs.netlify.com/routing/redirects/rewrites-proxies/#history-pushstate-and-single-page-apps